### PR TITLE
Update DataServlet and client script to adopt JSON fetching/parsing

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -23,6 +23,11 @@
       <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,19 +14,37 @@
 
 package com.google.sps.servlets;
 
+import com.google.gson.Gson;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
+/**
+ * Servlet that returns some example content of comments on the portfolio.
+ */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
+  private List<String> commentsList;
+
+  @Override
+  public void init() {
+    commentsList = new ArrayList<>();
+    commentsList.add("Wow, this website is great!");
+    commentsList.add("Cool website!");
+    commentsList.add("Why didn't you use TypeScript for the poker game?");
+  }
+
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
-    response.getWriter().println("Hello Peter!");
+    response.setContentType("application/json;");
+    Gson gson = new Gson();
+    String serializedJSON = gson.toJson(commentsList);
+    response.getWriter().println(serializedJSON);
   }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -86,7 +86,12 @@ function typeWriterEffect(charIndex, currentFactIndex) {
  * setting the `comments-container` div to the text.
  */
 async function displayServletContent() {
-  const res = await fetch('/data');
-  const text = await res.text();
-  document.getElementById('comments-section').innerText = text;
+  const res = await fetch("/data");
+  const json = await res.json();
+  if (!Array.isArray(json)) {
+    throw new Error("Response data is not an array");
+  }
+
+  document.getElementById("comments-section").innerHTML =
+    "<ul class=\x22comments-list\x22>" + json.map((comment) => `<li>${comment}</li>`).join("") + "</ul>";
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -93,5 +93,5 @@ async function displayServletContent() {
   }
 
   document.getElementById("comments-section").innerHTML =
-    "<ul class=\x22comments-list\x22>" + json.map((comment) => `<li>${comment}</li>`).join("") + "</ul>";
+    "<ul class=\"comments-list\">" + json.map((comment) => `<li>${comment}</li>`).join("") + "</ul>";
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -67,6 +67,11 @@ body {
   padding-top: 1em;
 }
 
+.comments-list {
+  list-style-type: none;
+  padding: 0;
+}
+
 .cta-button-container {
   clear: left;
 }


### PR DESCRIPTION
### Summary
This PR implements the feature from Week 3 Step 3 by refactoring the `DataServlet` to return dummy comment data as a serialized JSON instead of purely a string. The Gson library was used and added to the Maven `pom.xml` file as a dependency. The client-side JS fetches this data and parses the JSON array by using `.map()`, which will help modularize the code for further scaling and hopefully reduce future technical debt from our use of dummy data. 

### Screenshots
![Screenshot 2020-06-01 at 5 52 08 PM - Display 2](https://user-images.githubusercontent.com/7517829/83459442-651de700-a432-11ea-8fa5-ed83d8901bec.png)

### Test Plan 
Run `mvn package appengine:run` into the Cloud Shell to view a test server of the site by clicking Web Preview on the top right. Then scroll all the way down on the index page.
