### PR TITLE
Implement comments with usernames functionality (non-persistent storage)

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,6 +28,16 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <version>1.7.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.7.2</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -39,11 +49,22 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <!-- TODO: set project ID. -->
           <deploy.projectId>peterlwu-step-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>
+      <plugin>
+      <artifactId>maven-compiler-plugin</artifactId>
+      <configuration>
+        <annotationProcessorPaths>
+          <path>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>1.7.2</version>
+          </path>
+        </annotationProcessorPaths>
+      </configuration>
+    </plugin>
     </plugins>
   </build>
 </project>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,7 +14,9 @@
 
 package com.google.sps.servlets;
 
+import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,8 +37,8 @@ public class DataServlet extends HttpServlet {
   @Override
   public void init() {
     commentsList = new ArrayList<>();
-    commentsList.add(new Comment("Alice", "Wow, this website is great!"));
-    commentsList.add(new Comment("Bob", "Cool website!"));
+    commentsList.add(Comment.create("Alice", "Wow, this website is great!"));
+    commentsList.add(Comment.create("Bob", "Cool website!"));
   }
 
   @Override
@@ -51,37 +53,22 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String username = request.getParameter("comment-username");
     String commentText = request.getParameter("comment-input");
-    commentsList.add(new Comment(username, commentText));
+    commentsList.add(Comment.create(username, commentText));
     response.sendRedirect("/");
   }
 
-  /** Representation type for a comment, complete with a username and body text */
-  private class Comment {
-
-    private String name;
-    private String text;
-
-    /**
-     * Initalize the fields of this Comment using a constructor
-     * 
-     * @param name The username of the user posting the comment
-     * @param text The body text of the comment posted by the user
-     */
-    public Comment(String name, String text) {
-      this.name = name;
-      this.text = text;
+  /**
+   * Value class for a comment, complete with a username and body text. Generated
+   * with AutoValue.
+   */
+  @AutoValue
+  abstract static class Comment {
+    static Comment create(String name, String text) {
+      return new AutoValue_DataServlet_Comment(name, text);
     }
 
-    public String getName() {
-      return name;
-    }
+    abstract String name();
 
-    public String getComment() {
-      return text;
-    }
-
-    public String toString() {
-      return name + ": " + text;
-    }
+    abstract String text();
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -30,14 +30,13 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  private List<String> commentsList;
+  private List<Comment> commentsList;
 
   @Override
   public void init() {
     commentsList = new ArrayList<>();
-    commentsList.add("Wow, this website is great!");
-    commentsList.add("Cool website!");
-    commentsList.add("Why didn't you use TypeScript for the poker game?");
+    commentsList.add(new Comment("Alice", "Wow, this website is great!"));
+    commentsList.add(new Comment("Bob", "Cool website!"));
   }
 
   @Override
@@ -46,5 +45,43 @@ public class DataServlet extends HttpServlet {
     Gson gson = new Gson();
     String serializedJSON = gson.toJson(commentsList);
     response.getWriter().println(serializedJSON);
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String username = request.getParameter("comment-username");
+    String commentText = request.getParameter("comment-input");
+    commentsList.add(new Comment(username, commentText));
+    response.sendRedirect("/");
+  }
+
+  /** Representation type for a comment, complete with a username and body text */
+  private class Comment {
+
+    private String name;
+    private String text;
+
+    /**
+     * Initalize the fields of this Comment using a constructor
+     * 
+     * @param name The username of the user posting the comment
+     * @param text The body text of the comment posted by the user
+     */
+    public Comment(String name, String text) {
+      this.name = name;
+      this.text = text;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public String getComment() {
+      return text;
+    }
+
+    public String toString() {
+      return name + ": " + text;
+    }
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -160,6 +160,32 @@
     <div class="comments-container">
       <h2 class="comments-header">Comments</h2>
       <div id="comments-section"></div>
+      <hr />
+      <form action="/data" method="POST">
+        <h3>Add a Comment</h3>
+        <label for="comment-username" class="comments-label">Your Name:</label>
+        <br />
+        <input
+          type="text"
+          id="comment-username"
+          name="comment-username"
+          class="comments-field"
+          required
+        />
+        <br /><br />
+        <label for="comment-username" class="comments-label"
+          >Your Comment:
+        </label>
+        <br />
+        <textarea
+          name="comment-input"
+          placeholder="Enter your comment here..."
+          class="comments-area"
+          required
+        ></textarea>
+        <br /><br />
+        <input type="submit" />
+      </form>
     </div>
     <footer class="footer-white">
       Built from scratch with HTML + CSS + JavaScript.

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -164,27 +164,24 @@
       <form action="/data" method="POST">
         <h3>Add a Comment</h3>
         <label for="comment-username" class="comments-label">Your Name:</label>
-        <br />
         <input
           type="text"
           id="comment-username"
+          placeholder="John Doe"
           name="comment-username"
           class="comments-field"
           required
         />
-        <br /><br />
         <label for="comment-username" class="comments-label"
           >Your Comment:
         </label>
-        <br />
         <textarea
           name="comment-input"
           placeholder="Enter your comment here..."
           class="comments-area"
           required
         ></textarea>
-        <br /><br />
-        <input type="submit" />
+        <input type="submit" class="comments-submit" />
       </form>
     </div>
     <footer class="footer-white">

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -93,5 +93,5 @@ async function displayServletContent() {
   }
 
   document.getElementById("comments-section").innerHTML =
-    "<ul class=\"comments-list\">" + json.map((comment) => `<li>${comment}</li>`).join("") + "</ul>";
+    "<ul class=\"comments-list\">" + json.map(({name, text}) => `<li><b>${name}: </b>${text}</li>`).join("") + "</ul>";
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -55,6 +55,12 @@ body {
   text-align: left;
 }
 
+.comments-area {
+  width: 50%;
+  font: 1.5em var(--defaultFont);
+  padding: 0.5em 0.5em 0.5em 0.5em;
+}
+
 .comments-container {
   background: whitesmoke;
   min-height: 30vh;
@@ -67,9 +73,17 @@ body {
   padding-top: 1em;
 }
 
+.comments-label {
+  font: 1.1em var(--boldFont);
+}
+
 .comments-list {
   list-style-type: none;
   padding: 0;
+}
+
+.comments-field {
+  font: 1.5em var(--defaultFont);
 }
 
 .cta-button-container {
@@ -128,8 +142,7 @@ body {
   border-radius: 50px;
   box-shadow: 0 0 40px hsl(209, 100%, 77%);
   color: white;
-  font-family: var(--boldFont);
-  font-size: 24px;
+  font-family: 24px var(--boldFont);
   line-height: 50px;
   margin-top: 2.5em;
   position: absolute;

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -74,7 +74,9 @@ body {
 }
 
 .comments-label {
+  display: block;
   font: 1.1em var(--boldFont);
+  margin: 8px 0 16px 0;
 }
 
 .comments-list {
@@ -83,7 +85,27 @@ body {
 }
 
 .comments-field {
+  display: block;
   font: 1.5em var(--defaultFont);
+  margin: auto;
+}
+
+.comments-submit {
+  background: var(--motifColor);
+  border: none;
+  border-radius: 50px;
+  box-shadow: 0 0 40px hsl(209, 100%, 77%);
+  color: white;
+  display: block;
+  font: 1.3em var(--boldFont);
+  line-height: 50px;
+  margin: 24px auto 0 auto;
+  padding: 0 2em 0 2em;
+}
+
+.comments-submit:hover {
+  filter: brightness(90%);
+  cursor: pointer;
 }
 
 .cta-button-container {
@@ -142,7 +164,7 @@ body {
   border-radius: 50px;
   box-shadow: 0 0 40px hsl(209, 100%, 77%);
   color: white;
-  font-family: 24px var(--boldFont);
+  font: 24px var(--boldFont);
   line-height: 50px;
   margin-top: 2.5em;
   position: absolute;


### PR DESCRIPTION
### Summary
This PR implements the feature from Week 3 Step 4 + a bit extra by adding a comments form and a POST request in the `DataServlet` corresponding to the `/data` endpoint which handles the submission of the comment form. Use of an inner class in `DataServlet` better allows for modular displaying of the username and text data instead of as just a string, as I can change the styling of both of these elements later on. The storage of this data will be persistent as I move it to use Datastore in the next step, which I plan to do tomorrow.

### Screenshots
![My Portfolio _ Peter Wu](https://user-images.githubusercontent.com/7517829/83467090-f4cd9080-a446-11ea-896b-e064f24be265.gif)

### Test Plan 
Run `mvn package appengine:run` into the Cloud Shell to view a test server of the site by clicking Web Preview on the top right. Then scroll all the way down on the index page and add a comment. The page should refresh, and scroll down to see the updated comments list.