### PR TITLE
Complete MVP: Add NoSQL permanent storage using Datastore

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -38,6 +38,11 @@
       <artifactId>auto-value-annotations</artifactId>
       <version>1.7.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -45,10 +45,13 @@ public class DataServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
 
     List<Comment> comments = new ArrayList<>();
+    final String PROPERTY_NAME = "name";
+    final String PROPERTY_TEXT = "text";
+    final String PROPERTY_TIMESTAMP = "timestamp";
     for (Entity entity : results.asIterable()) {
-      String name = (String) entity.getProperty("name");
-      String text = (String) entity.getProperty("text");
-      long timestamp = (long) entity.getProperty("timestamp");
+      String name = (String) entity.getProperty(PROPERTY_NAME);
+      String text = (String) entity.getProperty(PROPERTY_TEXT);
+      long timestamp = (long) entity.getProperty(PROPERTY_TIMESTAMP);
 
       Comment comment = Comment.create(name, text, timestamp);
       comments.add(comment);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -40,7 +40,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("Task").addSort("timestamp", SortDirection.DESCENDING);
+    Query query = new Query("comment").addSort("timestamp", SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -15,6 +15,9 @@
 package com.google.sps.servlets;
 
 import com.google.auto.value.AutoValue;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;
 
 import java.io.IOException;
@@ -32,20 +35,11 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  private List<Comment> commentsList;
-
-  @Override
-  public void init() {
-    commentsList = new ArrayList<>();
-    commentsList.add(Comment.create("Alice", "Wow, this website is great!"));
-    commentsList.add(Comment.create("Bob", "Cool website!"));
-  }
-
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     response.setContentType("application/json;");
     Gson gson = new Gson();
-    String serializedJSON = gson.toJson(commentsList);
+    String serializedJSON = gson.toJson("placeholder");
     response.getWriter().println(serializedJSON);
   }
 
@@ -53,7 +47,13 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String username = request.getParameter("comment-username");
     String commentText = request.getParameter("comment-input");
-    commentsList.add(Comment.create(username, commentText));
+
+    Entity commentEntity = new Entity("comment");
+    commentEntity.setProperty("name", username);
+    commentEntity.setProperty("text", commentText);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(commentEntity);
     response.sendRedirect("/");
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -38,20 +38,22 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
+  private static final String COMMENT_ENTITY_PROPERTY_NAME = "name";
+  private static final String COMMENT_ENTITY_PROPERTY_TEXT = "text";
+  private static final String COMMENT_ENTITY_PROPERTY_TIMESTAMP = "timestamp";
+
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    Query query = new Query("comment").addSort("timestamp", SortDirection.DESCENDING);
+    Query query = new Query("comment").addSort(COMMENT_ENTITY_PROPERTY_TIMESTAMP, SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
     List<Comment> comments = new ArrayList<>();
-    final String PROPERTY_NAME = "name";
-    final String PROPERTY_TEXT = "text";
-    final String PROPERTY_TIMESTAMP = "timestamp";
+
     for (Entity entity : results.asIterable()) {
-      String name = (String) entity.getProperty(PROPERTY_NAME);
-      String text = (String) entity.getProperty(PROPERTY_TEXT);
-      long timestamp = (long) entity.getProperty(PROPERTY_TIMESTAMP);
+      String name = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_NAME);
+      String text = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_TEXT);
+      long timestamp = (long) entity.getProperty(COMMENT_ENTITY_PROPERTY_TIMESTAMP);
 
       Comment comment = Comment.create(name, text, timestamp);
       comments.add(comment);
@@ -70,9 +72,9 @@ public class DataServlet extends HttpServlet {
     long timestamp = System.currentTimeMillis();
 
     Entity commentEntity = new Entity("comment");
-    commentEntity.setProperty("name", username);
-    commentEntity.setProperty("text", commentText);
-    commentEntity.setProperty("timestamp", timestamp);
+    commentEntity.setProperty(COMMENT_ENTITY_PROPERTY_NAME, username);
+    commentEntity.setProperty(COMMENT_ENTITY_PROPERTY_TEXT, commentText);
+    commentEntity.setProperty(COMMENT_ENTITY_PROPERTY_TIMESTAMP, timestamp);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -93,5 +93,9 @@ async function displayServletContent() {
   }
 
   document.getElementById("comments-section").innerHTML =
-    "<ul class=\"comments-list\">" + json.map(({name, text}) => `<li><b>${name}: </b>${text}</li>`).join("") + "</ul>";
+    '<ul class="comments-list">' +
+    json
+      .map(({ name, text, _ }) => `<li><b>${name}: </b>${text}</li>`)
+      .join("") +
+    "</ul>";
 }


### PR DESCRIPTION
### Summary
This PR introduces persistent storage to the webapp, through the use of Datastore in the `DataServlet`. We modify the POST request developed earlier to add an `Entity` to the Datastore representing the name, text, and timestamp of a certain comment, and then adapt the GET request to query the Datastore in descending order based on the timestamp. The destructuring in the JavaScript fetching is adjusted similarly to account for the new added field in the `Comment` data class.

### Screenshots
![Screenshot 2020-06-02 at 5 40 56 PM](https://user-images.githubusercontent.com/7517829/83573251-0ec7ab80-a4f9-11ea-90e5-29107c61f0a6.png)

### Test Plan 
Run `mvn package appengine:run` into the Cloud Shell to view a test server of the site by clicking Web Preview on the top right. Then scroll all the way down on the index page and add a comment. The page should refresh, and scroll down to see the updated comments list. These comments should persist after you stop the server and restart it again.