### PR TITLE
Query params for DataServlet: list certain # of comments out of n comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -43,6 +43,11 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.0-jre</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -22,6 +22,7 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
+import com.google.common.collect.Iterables;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -50,19 +51,19 @@ public class DataServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(query);
 
     List<Comment> comments = new ArrayList<>();
-    
-    if (requestParam == null) {
-    for (Entity entity : results.asIterable()) {
+    Iterable<Entity> entityIterable = results.asIterable();
+    if (requestParam != null) {
+      int numCommentsToReturn = Integer.parseInt(requestParam);
+      entityIterable = Iterables.limit(entityIterable, numCommentsToReturn);
+    }
+
+    for (Entity entity : entityIterable) {
       String name = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_NAME);
       String text = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_TEXT);
       long timestamp = (long) entity.getProperty(COMMENT_ENTITY_PROPERTY_TIMESTAMP);
 
       Comment comment = Comment.create(name, text, timestamp);
       comments.add(comment);
-    }
-    } else {
-        int numCommentsToReturn = Integer.parseInt(requestParam);
-        comments.add(Comment.create("dummy", numCommentsToReturn, 3434))
     }
 
     response.setContentType("application/json;");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -44,12 +44,14 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String requestParam = request.getParameter("list");
     Query query = new Query("comment").addSort(COMMENT_ENTITY_PROPERTY_TIMESTAMP, SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
     List<Comment> comments = new ArrayList<>();
-
+    
+    if (requestParam == null) {
     for (Entity entity : results.asIterable()) {
       String name = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_NAME);
       String text = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_TEXT);
@@ -57,6 +59,10 @@ public class DataServlet extends HttpServlet {
 
       Comment comment = Comment.create(name, text, timestamp);
       comments.add(comment);
+    }
+    } else {
+        int numCommentsToReturn = Integer.parseInt(requestParam);
+        comments.add(Comment.create("dummy", numCommentsToReturn, 3434))
     }
 
     response.setContentType("application/json;");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -45,7 +45,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    String requestParam = request.getParameter("list");
+    String requestParam = request.getParameter("limit");
     Query query = new Query("comment").addSort(COMMENT_ENTITY_PROPERTY_TIMESTAMP, SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -159,6 +159,19 @@
     </div>
     <div class="comments-container">
       <h2 class="comments-header">Comments</h2>
+      <label for="comment-number-shown">
+        Show
+      </label>
+      <select
+        name="comment-number-shown"
+        id="comment-number-shown"
+        class="comments-menu"
+      >
+        <option value="5" selected>5 comments</option>
+        <option value="10">10 comments</option>
+        <option value="all">All comments</option>
+        <option value="none">No comments</option>
+      </select>
       <div id="comments-section"></div>
       <hr />
       <form action="/data" method="POST">

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -84,7 +84,8 @@ function typeWriterEffect(charIndex, currentFactIndex) {
 /**
  * Renders the plaintext as a result of calling the /data GET endpoint by
  * setting the `comments-container` div to the text with certain number of
- * comments list.
+ * comments list. Throws an error if the endpoint does not return a JSON
+ * array.
  * @param {number} numCommentsToShow. If === -1, then show all comments.
  */
 async function displayServletContent(numCommentsToShow) {
@@ -108,7 +109,8 @@ async function displayServletContent(numCommentsToShow) {
 }
 
 // Listen for changes in comment number selected and rerender comments section
-// as needed
+// as needed. Throws an error if cases for 5, 10, all, or none are not
+// encountered.
 const selected = document.querySelector("#comment-number-shown");
 selected.addEventListener("change", (event) => {
   switch (event.target.value) {
@@ -116,7 +118,7 @@ selected.addEventListener("change", (event) => {
       displayServletContent(5);
       break;
     case "10":
-      displayServletContent(5);
+      displayServletContent(10);
       break;
     case "all":
       displayServletContent(-1);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -18,7 +18,7 @@ let alternateOnOff = false;
 // Function to be run on index page load. Calls all initial functions.
 function init() {
   typeWriterEffect(0, 0);
-  displayServletContent();
+  displayServletContent(5);
 }
 
 // Interval for repeated blinking text effect on page
@@ -82,20 +82,49 @@ function typeWriterEffect(charIndex, currentFactIndex) {
 }
 
 /**
- * Displays the plaintext as a result of calling the /data GET endpoint by
- * setting the `comments-container` div to the text.
+ * Renders the plaintext as a result of calling the /data GET endpoint by
+ * setting the `comments-container` div to the text with certain number of
+ * comments list.
+ * @param {number} numCommentsToShow. If === -1, then show all comments.
  */
-async function displayServletContent() {
-  const res = await fetch("/data");
+async function displayServletContent(numCommentsToShow) {
+  const res =
+    numCommentsToShow === -1
+      ? await fetch("/data")
+      : await fetch(`/data?list=${numCommentsToShow}`);
   const json = await res.json();
   if (!Array.isArray(json)) {
     throw new Error("Response data is not an array");
   }
 
   document.getElementById("comments-section").innerHTML =
-    '<ul class="comments-list">' +
-    json
-      .map(({ name, text, _ }) => `<li><b>${name}: </b>${text}</li>`)
-      .join("") +
-    "</ul>";
+    json.length === 0
+      ? "<h5>No comments to show.</h5>"
+      : '<ul class="comments-list">' +
+        json
+          .map(({ name, text, _ }) => `<li><b>${name}: </b>${text}</li>`)
+          .join("") +
+        "</ul>";
 }
+
+// Listen for changes in comment number selected and rerender comments section
+// as needed
+const selected = document.querySelector("#comment-number-shown");
+selected.addEventListener("change", (event) => {
+  switch (event.target.value) {
+    case "5":
+      displayServletContent(5);
+      break;
+    case "10":
+      displayServletContent(5);
+      break;
+    case "all":
+      displayServletContent(-1);
+      break;
+    case "none":
+      displayServletContent(0);
+      break;
+    default:
+      throw new Error("Unimplemented # comments encountered");
+  }
+});

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -92,7 +92,7 @@ async function displayServletContent(numCommentsToShow) {
   const res =
     numCommentsToShow === -1
       ? await fetch("/data")
-      : await fetch(`/data?list=${numCommentsToShow}`);
+      : await fetch(`/data?limit=${numCommentsToShow}`);
   const json = await res.json();
   if (!Array.isArray(json)) {
     throw new Error("Response data is not an array");

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -65,6 +65,13 @@ body {
   background: whitesmoke;
   min-height: 30vh;
   text-align: center;
+  padding-bottom: 2em;
+}
+
+.comments-field {
+  display: block;
+  font: 1.5em var(--defaultFont);
+  margin: auto;
 }
 
 .comments-header {
@@ -84,10 +91,8 @@ body {
   padding: 0;
 }
 
-.comments-field {
-  display: block;
-  font: 1.5em var(--defaultFont);
-  margin: auto;
+.comments-menu {
+  margin-bottom: 1.5em;
 }
 
 .comments-submit {
@@ -99,7 +104,7 @@ body {
   display: block;
   font: 1.3em var(--boldFont);
   line-height: 50px;
-  margin: 24px auto 0 auto;
+  margin: 24px auto 24px auto;
   padding: 0 2em 0 2em;
 }
 


### PR DESCRIPTION
### Summary
This PR introduces parsing of query params to the `DataServlet` `doGet` endpoint. Uses the **Guava** library `Iterables` class to truncate the `Iterable` results returned by the query to the Datastore for the comments based on the query param. This is connected to the frontend by parametrizing the `displayServletContent` function and adding an event listener to a select dropdown menu of the # of comments to display.

### Screenshots
![GIF of comment query](https://user-images.githubusercontent.com/7517829/83670215-d24f8a80-a5a0-11ea-8f66-375216add00b.gif)

### Test Plan 
Run `mvn package appengine:run` into the Cloud Shell to view a test server of the site by clicking Web Preview on the top right. Then scroll all the way down on the index page and add some comments and then click the select dropdown menu to try to view the most recent `n` comments. 

### Notes
New dependency added on `com.google.guava` in Maven.