### PR TITLE
Add delete all comments servlet and feature

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -1,0 +1,35 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.gson.Gson;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet that handles deletion of all comments in the Datastore
+ */
+@WebServlet("/delete-data")
+public class DeleteDataServlet extends HttpServlet {
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(new Query("comment"));
+    Iterable<Entity> entityIterable = results.asIterable();
+
+    List<Entity> commentEntitiesToDelete = ImmutableList.copyOf(entityIterable);
+    datastore.delete(commentEntitiesToDelete);
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -5,12 +5,8 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
-import com.google.gson.Gson;
-import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -29,7 +25,8 @@ public class DeleteDataServlet extends HttpServlet {
     PreparedQuery results = datastore.prepare(new Query("comment"));
     Iterable<Entity> entityIterable = results.asIterable();
 
-    List<Entity> commentEntitiesToDelete = ImmutableList.copyOf(entityIterable);
-    datastore.delete(commentEntitiesToDelete);
+    for (Entity entity : entityIterable) {
+      datastore.delete(entity.getKey());
+    }
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -172,6 +172,9 @@
         <option value="all">All comments</option>
         <option value="none">No comments</option>
       </select>
+      <button onClick="deleteComments()" class="comments-delete">
+        Delete All Comments
+      </button>
       <div id="comments-section"></div>
       <hr />
       <form action="/data" method="POST">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -172,7 +172,11 @@
         <option value="all">All comments</option>
         <option value="none">No comments</option>
       </select>
-      <button onClick="deleteComments()" class="comments-delete">
+      <button 
+        id="comment-delete-button" 
+        onClick="deleteComments()" 
+        class="comments-delete"
+      >
         Delete All Comments
       </button>
       <div id="comments-section"></div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -98,14 +98,19 @@ async function displayServletContent(numCommentsToShow) {
     throw new Error("Response data is not an array");
   }
 
-  document.getElementById("comments-section").innerHTML =
-    json.length === 0
-      ? "<h5>No comments to show.</h5>"
-      : '<ul class="comments-list">' +
-        json
-          .map(({ name, text, _ }) => `<li><b>${name}: </b>${text}</li>`)
-          .join("") +
-        "</ul>";
+  if (json.length === 0) {
+    document.getElementById("comments-section").innerHTML =
+      "<h5>No comments to show.</h5>";
+    document.getElementById("comment-delete-button").style.display = "none";
+  } else {
+    document.getElementById("comments-section").innerHTML =
+      '<ul class="comments-list">' +
+      json
+        .map(({ name, text, _ }) => `<li><b>${name}: </b>${text}</li>`)
+        .join("") +
+      "</ul>";
+    document.getElementById("comment-delete-button").style.display = "block";
+  }
 }
 
 // Listen for changes in comment number selected and rerender comments section

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -130,3 +130,9 @@ selected.addEventListener("change", (event) => {
       throw new Error("Unimplemented # comments encountered");
   }
 });
+
+function deleteComments() {
+  fetch("/delete-data", { method: "POST" }).then(() =>
+    displayServletContent(-1)
+  );
+}

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -68,6 +68,23 @@ body {
   padding-bottom: 2em;
 }
 
+.comments-delete {
+  background: #d40202;
+  border: none;
+  border-radius: 20px;
+  color: white;
+  display: block;
+  font: 1em var(--boldFont);
+  line-height: 30px;
+  margin: 0 auto 0 auto;
+  padding: 0 2em 0 2em;
+}
+
+.comments-delete:hover {
+  cursor: pointer;
+  filter: brightness(90%);
+}
+
 .comments-field {
   display: block;
   font: 1.5em var(--defaultFont);


### PR DESCRIPTION
### Summary
This PR implements a Delete All Comments button that conditionally shows when there are comments, and not otherwise. It uses a `POST` request in the `/delete-data` endpoint, and a new servlet has been created for this. 

### Screenshots
![screenshot for PR](https://user-images.githubusercontent.com/7517829/83699015-f62ac480-a5d0-11ea-93f9-46ea7568f446.gif)

### Test Plan 
Run `mvn package appengine:run` into the Cloud Shell to view a test server of the site by clicking Web Preview on the top right. Then scroll all the way down on the index page and add some comments and then click the 'Delete All Comments' button to delete.

### Notes
This feature is pretty dangerous in production since it gives any user the ability to purge the database of comments. However, this was the last step in the week 3 tutorial, so I implemented it for the sake of practice (may not deploy this feature).