### PR TITLE
Finalize Maps Data Visualization: Add stats displays and summary stats

### DIFF
--- a/portfolio/src/main/webapp/covid-19-viz.js
+++ b/portfolio/src/main/webapp/covid-19-viz.js
@@ -8,23 +8,34 @@ let min = Number.MAX_VALUE;
 let max = -Number.MAX_VALUE;
 
 /**
- * Fetches data from the COVID-19 API on confirmed cases per U.S.
+ * Fetches data from the COVID-19 API on confirmed cases and deaths per U.S.
  * state/territory and sets the data as a property on each state/territory.
- * @param {google.maps.Map} map 
+ * @param {google.maps.Map} map
  */
 async function renderCOVIDData(map) {
   const data = await fetch("https://api.covid19api.com/live/country/us");
   const json = await data.json();
 
-  json.forEach(({ Confirmed, Province }) => {
+  let totalData = [];
+  json.forEach(({ Confirmed, Province, Deaths }) => {
     if (map.data.getFeatureById(Province) !== undefined) {
       min = Confirmed < min ? Confirmed : min;
       max = Confirmed > max ? Confirmed : max;
       map.data.getFeatureById(Province).setProperty("cases", Confirmed);
+      map.data.getFeatureById(Province).setProperty("deaths", Deaths);
+
+      /*update totalData with set-like behavior (in case of repeats in data set,
+      the most recent values are used) */
+      totalData = totalData.filter(({ name }) => name !== Province);
+      totalData.push({ name: Province, cases: Confirmed, deaths: Deaths });
     }
   });
-  document.getElementById("min").textContent = min.toLocaleString();
-  document.getElementById("max").textContent = max.toLocaleString();
+
+  const totalCases = totalData.reduce((acc, curr) => acc + curr.cases, 0);
+  const totalDeaths = totalData.reduce((acc, curr) => acc + curr.deaths, 0);
+  document.getElementById(
+    "data-summary"
+  ).textContent = `Total Cases: ${totalCases.toLocaleString()} | Total Deaths: ${totalDeaths.toLocaleString()}`;
 }
 
 /**
@@ -41,9 +52,10 @@ function styleCallback(feature) {
   for (let i = 0; i < 3; i++) {
     color[i] = (high[i] - low[i]) * delta + low[i];
   }
+  const weight = feature.getProperty("state") === "hover" ? 3 : 1;
 
   return {
-    strokeWeight: 1.5,
+    strokeWeight: weight,
     strokeColor: "#000",
     fillColor: "hsl(" + color[0] + "," + color[1] + "%," + color[2] + "%)",
     fillOpacity: 0.8,
@@ -60,6 +72,8 @@ async function initializeCOVIDMap() {
     zoom: 4.9,
   });
   map.data.setStyle(styleCallback);
+  map.data.addListener("mouseover", mouseOverCallback);
+  map.data.addListener("mouseout", mouseOutCallback);
 
   await map.data.loadGeoJson(
     "https://storage.googleapis.com/mapsdevsite/json/states.js",
@@ -67,4 +81,22 @@ async function initializeCOVIDMap() {
   );
   google.maps.event.trigger(document.getElementById("cases"), "change");
   renderCOVIDData(map);
+}
+
+function mouseOverCallback(event) {
+  event.feature.setProperty("state", "hover");
+
+  document.getElementById("data-label").textContent = event.feature.getProperty(
+    "NAME"
+  );
+  document.getElementById("data-value").textContent =
+    event.feature.getProperty("cases").toLocaleString() +
+    " confirmed cases, " +
+    event.feature.getProperty("deaths").toLocaleString() +
+    " deaths";
+  document.getElementById("data-box").style.display = "block";
+}
+
+function mouseOutCallback(event) {
+  event.feature.setProperty("state", "normal");
 }

--- a/portfolio/src/main/webapp/covid19.html
+++ b/portfolio/src/main/webapp/covid19.html
@@ -5,6 +5,7 @@
     <title>COVID-19 Map Visualization</title>
     <link rel="stylesheet" href="constants.css" />
     <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style-covid19.css" />
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
     <link rel="icon" href="favicon.ico" type="image/x-icon" />
     <script async defer src="covid-19-viz.js"></script>
@@ -24,7 +25,13 @@
     </div>
     <div class="maps-container-covid">
       <h2 class="maps-header">USA COVID-19 Data Visualization</h2>
-
+      <div id="data-box" class="box-card">
+        <label id="data-label" for="data-value"></label>
+        <span id="data-value">Hover over a state for COVID-19 statistics</span>
+      </div>
+      <div id="data-box-summary" class="box-card">
+        <span id="data-summary"></span>
+      </div>
       <div id="map-covid"></div>
     </div>
     <footer class="footer-white">

--- a/portfolio/src/main/webapp/style-covid19.css
+++ b/portfolio/src/main/webapp/style-covid19.css
@@ -1,0 +1,28 @@
+.box-card {
+  background: white;
+  box-shadow: 0 4px 6px -4px #000;
+  font-size: 10px;
+  padding: 5px 10px;
+  position: absolute;
+  text-align: center;
+  z-index: 5;
+}
+
+#data-box {
+  right: 0;
+}
+
+#data-box-summary {
+  left: 50%;
+  font: 1em var(--boldFont);
+  transform: translate(-50%, 0);
+}
+
+#data-value {
+  font: 2em var(--boldFont);
+}
+
+#data-label {
+  font-size: 2em;
+  padding-right: 10px;
+}


### PR DESCRIPTION
### Summary
This PR adds data boxes at the top right and top middle of the COVID-19 data visualization map. The top right data box changes on hover of each state/territory to show the corresponding stats for the state, and the top middle box is a statically computed value on page load of the total cases and deaths resulting from the pandemic.

### Screenshots
![COVID map finalized](https://user-images.githubusercontent.com/7517829/84331468-3f8e8d00-ab58-11ea-9257-ff6562421bdc.gif)

### Test Plan
From the `index` page, navigate using the navbar at the top to the COVID-19 Visualization page. View the map and interact with it by hovering on the states.

### Notes
Unfortunately, it looks like the dataset from this API is not getting updated anymore (or hasn't received an update in the last month), which is a bummer. The computations done for the summary statistics show this by being much lower than the current stats. 

This is a shame, but the visualization and stats are data-driven and I have chosen to stick with it for the sake of the exercise.