### PR TITLE
Integrate Users API: Authentication for Comments Section

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>guava</artifactId>
       <version>28.0-jre</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
@@ -28,10 +28,17 @@ public class AuthStatusServlet extends HttpServlet {
     if (userService.isUserLoggedIn()) {
       String logoutUrl = userService.createLoginURL(AUTH_LOGIN_LOGOUT_REDIRECT_URI);
       String userEmail = userService.getCurrentUser().getEmail();
-      statusData = UserAuthStatus.create(true, userEmail, "", logoutUrl);
+      statusData = UserAuthStatus.builder()
+                    .setIsLoggedIn(true)
+                    .setEmail(userEmail)
+                    .setLogoutUrl(logoutUrl)
+                    .build();
     } else {
       String loginUrl = userService.createLoginURL(AUTH_LOGIN_LOGOUT_REDIRECT_URI);
-      statusData = UserAuthStatus.create(false, "", loginUrl, "");
+      statusData = UserAuthStatus.builder()
+                    .setIsLoggedIn(false)
+                    .setLoginUrl(loginUrl)
+                    .build();
     }
 
     response.setContentType("application/json;");
@@ -47,9 +54,6 @@ public class AuthStatusServlet extends HttpServlet {
    */
   @AutoValue
   abstract static class UserAuthStatus {
-    static UserAuthStatus create(boolean isLoggedIn, String email, String loginUrl, String logoutUrl) {
-      return new AutoValue_AuthStatusServlet_UserAuthStatus(isLoggedIn, email, loginUrl, logoutUrl);
-    }
 
     abstract boolean isLoggedIn();
 
@@ -58,5 +62,22 @@ public class AuthStatusServlet extends HttpServlet {
     abstract String loginUrl();
 
     abstract String logoutUrl();
+
+    static Builder builder() {
+      return AutoValue_AuthStatusServlet_UserAuthStatus.builder();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setIsLoggedIn(boolean value);
+
+      abstract Builder setEmail(String value);
+
+      abstract Builder setLoginUrl(String value);
+
+      abstract Builder setLogoutUrl(String value);
+
+      abstract UserAuthStatus build();
+    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
@@ -28,10 +28,10 @@ public class AuthStatusServlet extends HttpServlet {
     if (userService.isUserLoggedIn()) {
       String logoutUrl = userService.createLoginURL(AUTH_LOGIN_LOGOUT_REDIRECT_URI);
       String userEmail = userService.getCurrentUser().getEmail();
-      statusData = UserAuthStatus.create(true, userEmail, null, logoutUrl);
+      statusData = UserAuthStatus.create(true, userEmail, "", logoutUrl);
     } else {
       String loginUrl = userService.createLoginURL(AUTH_LOGIN_LOGOUT_REDIRECT_URI);
-      statusData = UserAuthStatus.create(false, null, loginUrl, null);
+      statusData = UserAuthStatus.create(false, "", loginUrl, "");
     }
 
     response.setContentType("application/json;");
@@ -42,9 +42,8 @@ public class AuthStatusServlet extends HttpServlet {
 
   /**
    * Value class for a certain authenticated/unauthenticated user, with a boolean
-   * repesenting login status, email (can be null if user is logged out), and
-   * login url or logout url (one of which is null if the user is logged in or
-   * logged out).
+   * repesenting login status, email, and login url or logout url. If one of these
+   * are not avaiable, the empty string is used.
    */
   @AutoValue
   abstract static class UserAuthStatus {

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
@@ -64,7 +64,10 @@ public class AuthStatusServlet extends HttpServlet {
     abstract String logoutUrl();
 
     static Builder builder() {
-      return AutoValue_AuthStatusServlet_UserAuthStatus.builder();
+      return new AutoValue_AuthStatusServlet_UserAuthStatus.Builder()
+                   .setEmail("none")
+                   .setLoginUrl("none")
+                   .setLogoutUrl("none");
     }
 
     @AutoValue.Builder

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthStatusServlet.java
@@ -1,0 +1,63 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet that handles authentication: provides login and logout URLs for users
+ * and checks login status of the user
+ */
+@WebServlet("/auth-status")
+public class AuthStatusServlet extends HttpServlet {
+
+  private static final String AUTH_LOGIN_LOGOUT_REDIRECT_URI = "/";
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    UserAuthStatus statusData;
+    if (userService.isUserLoggedIn()) {
+      String logoutUrl = userService.createLoginURL(AUTH_LOGIN_LOGOUT_REDIRECT_URI);
+      String userEmail = userService.getCurrentUser().getEmail();
+      statusData = UserAuthStatus.create(true, userEmail, null, logoutUrl);
+    } else {
+      String loginUrl = userService.createLoginURL(AUTH_LOGIN_LOGOUT_REDIRECT_URI);
+      statusData = UserAuthStatus.create(false, null, loginUrl, null);
+    }
+
+    response.setContentType("application/json;");
+    Gson gson = new Gson();
+    String serializedJSON = gson.toJson(statusData);
+    response.getWriter().println(serializedJSON);
+  }
+
+  /**
+   * Value class for a certain authenticated/unauthenticated user, with a boolean
+   * repesenting login status, email (can be null if user is logged out), and
+   * login url or logout url (one of which is null if the user is logged in or
+   * logged out).
+   */
+  @AutoValue
+  abstract static class UserAuthStatus {
+    static UserAuthStatus create(boolean isLoggedIn, String email, String loginUrl, String logoutUrl) {
+      return new AutoValue_AuthStatusServlet_UserAuthStatus(isLoggedIn, email, loginUrl, logoutUrl);
+    }
+
+    abstract boolean isLoggedIn();
+
+    abstract String email();
+
+    abstract String loginUrl();
+
+    abstract String logoutUrl();
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -49,12 +49,6 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    UserService userService = UserServiceFactory.getUserService();
-    if (!userService.isUserLoggedIn()) {
-      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-      return;
-    }
-
     String requestParam = request.getParameter("limit");
     Query query = new Query("comment").addSort(COMMENT_ENTITY_PROPERTY_TIMESTAMP, SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -69,7 +63,7 @@ public class DataServlet extends HttpServlet {
 
     for (Entity entity : entityIterable) {
       String name = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_NAME);
-      String email = userService.getCurrentUser().getEmail();
+      String email = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_EMAIL);
       String text = (String) entity.getProperty(COMMENT_ENTITY_PROPERTY_TEXT);
       long timestamp = (long) entity.getProperty(COMMENT_ENTITY_PROPERTY_TIMESTAMP);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -5,6 +5,8 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 
 import java.io.IOException;
 
@@ -21,6 +23,12 @@ public class DeleteDataServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    if (!userService.isUserLoggedIn()) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return;
+    }
+
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(new Query("comment"));
     Iterable<Entity> entityIterable = results.asIterable();

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -222,8 +222,9 @@
         <br />
       </form>
     </div>
-    <div class="comments-container">
+    <div class="comments-container" id="comments-div">
       <h2 class="form-header">Comments</h2>
+      <h4 id="login-greeting"></h4>
       <label for="comment-number-shown">
         Show
       </label>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -224,7 +224,7 @@
     </div>
     <div class="comments-container" id="comments-div">
       <h2 class="form-header">Comments</h2>
-      <h4 id="login-greeting"></h4>
+      <div id="login-greeting"></div>
       <label for="comment-number-shown">
         Show
       </label>
@@ -261,29 +261,31 @@
       </button>
       <div id="comments-section"></div>
       <hr />
-      <form id="comments-form">
-        <h3>Add a Comment</h3>
-        <label for="comment-username" class="form-label">Your Name:</label>
-        <input
-          type="text"
-          id="comment-username"
-          placeholder="John Doe"
-          name="comment-username"
-          class="form-field"
-          required
-        />
-        <label for="comment-username" class="form-label">
-          Your Comment:
-        </label>
-        <textarea
-          id="comment-input"
-          name="comment-input"
-          placeholder="Enter your comment here..."
-          class="form-area"
-          required
-        ></textarea>
-        <input type="submit" onClick="addComment()" class="comments-submit" />
-      </form>
+      <div id="comments-form-div">
+        <form id="comments-form">
+          <h3>Add a Comment</h3>
+          <label for="comment-username" class="form-label">Your Name:</label>
+          <input
+            type="text"
+            id="comment-username"
+            placeholder="John Doe"
+            name="comment-username"
+            class="form-field"
+            required
+          />
+          <label for="comment-username" class="form-label">
+            Your Comment:
+          </label>
+          <textarea
+            id="comment-input"
+            name="comment-input"
+            placeholder="Enter your comment here..."
+            class="form-area"
+            required
+          ></textarea>
+          <input type="submit" onClick="addComment()" class="comments-submit" />
+        </form>
+      </div>
     </div>
     <footer class="footer-white">
       Built from scratch with HTML + CSS + JavaScript.

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -22,6 +22,7 @@ function init() {
   typeWriterEffect(0, 0);
   displayServletContent(5);
   initializeMap();
+  checkAuth();
 }
 
 // Interval for repeated blinking text effect on page
@@ -380,5 +381,20 @@ async function getAddress() {
     } else {
       alert(`Error! ${json.error_message}`);
     }
+  }
+}
+
+async function checkAuth() {
+  const response = await fetch("/auth-status");
+  const { isLoggedIn, email, loginUrl, logoutUrl } = await response.json();
+
+  if (isLoggedIn) {
+    document.getElementById(
+      "login-greeting"
+    ).innerText = `You are logged in as ${email}.`;
+  } else {
+    document.getElementById(
+      "comments-div"
+    ).innerHTML = `<p>Login to post a comment <a href="${loginUrl}">here</a>.</p>`;
   }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -396,9 +396,11 @@ async function checkAuth() {
     document.getElementById(
       "login-greeting"
     ).innerHTML = `<p>You are logged in as ${email}. <a href="${logoutUrl}">Logout</a></p>`;
+    document.getElementById("comment-delete-button").style.display = "block";
   } else {
     document.getElementById(
       "comments-form-div"
     ).innerHTML = `<p class="login-text">Login to post a comment <a href="${loginUrl}">here</a>.</p>`;
+    document.getElementById("comment-delete-button").style.display = "none";
   }
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -384,6 +384,10 @@ async function getAddress() {
   }
 }
 
+/**
+ * Fetches auth status of client from backend and renders corresponding
+ * status to the DOM, with a login/logout URL.
+ */
 async function checkAuth() {
   const response = await fetch("/auth-status");
   const { isLoggedIn, email, loginUrl, logoutUrl } = await response.json();
@@ -391,10 +395,10 @@ async function checkAuth() {
   if (isLoggedIn) {
     document.getElementById(
       "login-greeting"
-    ).innerText = `You are logged in as ${email}.`;
+    ).innerHTML = `<p>You are logged in as ${email}. <a href="${logoutUrl}">Logout</a></p>`;
   } else {
     document.getElementById(
-      "comments-div"
-    ).innerHTML = `<p>Login to post a comment <a href="${loginUrl}">here</a>.</p>`;
+      "comments-form-div"
+    ).innerHTML = `<p class="login-text">Login to post a comment <a href="${loginUrl}">here</a>.</p>`;
   }
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -246,6 +246,12 @@ button:hover {
   width: 35%;
 }
 
+.login-text {
+  font-size: 1.5em;
+  margin: 0;
+  padding-top: 3em;
+}
+
 #logo-button:hover {
   filter: brightness(120%);
 }


### PR DESCRIPTION
### Summary
This PR implements login/logout with the Users API through App Engine. In this diff,

- The Users API is added as a dependency in Maven's `pom.xml`
- The `DataServlet` is modified so that posts can only be created if the user is authenticated. Otherwise, error code `401` is sent back (this behavior is not accessible in the first place on client-side)
- `AuthStatusServlet` is created with the `/auth-status` endpoint, which has a sole `GET` request returning auth data as JSON
- Client-side is updated such that auth status is checked on page load, conditionally rendering the add comment section and login/logout options.

### Screenshots
![Users API demo](https://user-images.githubusercontent.com/7517829/84446647-f734a500-ac13-11ea-9f4c-606a2f1e8f18.gif)

### Test Plan
Using a live dev server on Cloud Shell,  scroll to the bottom (comments section). Try logging in with an email, and posting a comment, and then logging out ensures that you once again cannot comment.