### PR TITLE
Implement Optional Attendees Support with Tests

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -66,7 +66,7 @@ public final class FindMeetingQuery {
    * @return Collection of TimeRange objects representing valid meeting time
    *         intervals
    */
-  private Collection<TimeRange> getValidMeetingTimeRanges(List<TimeRange> busyTimeRanges, MeetingRequest request) {
+  private static Collection<TimeRange> getValidMeetingTimeRanges(List<TimeRange> busyTimeRanges, MeetingRequest request) {
     if (busyTimeRanges.size() == 0) {
       return Arrays.asList(TimeRange.WHOLE_DAY);
     }
@@ -103,7 +103,7 @@ public final class FindMeetingQuery {
    * @param attendees Collection of attendee string names
    * @return List of time ranges where attendees are engaged in other events.
    */
-  private List<TimeRange> getBusyTimeRanges(Collection<Event> events, Collection<String> attendees) {
+  private static List<TimeRange> getBusyTimeRanges(Collection<Event> events, Collection<String> attendees) {
     List<TimeRange> busyTimeRanges = new ArrayList<TimeRange>();
     for (Event event : events) {
       Set<String> currEventAttendees = event.getAttendees();
@@ -124,7 +124,7 @@ public final class FindMeetingQuery {
    * @param sortedtimeRanges List of TimeRange objects that must be ordered by
    *                         starting time
    */
-  private void discretizeSortedTimeRanges(List<TimeRange> sortedTimeRanges) {
+  private static void discretizeSortedTimeRanges(List<TimeRange> sortedTimeRanges) {
     ListIterator<TimeRange> iter = sortedTimeRanges.listIterator();
     TimeRange prevTimeRange = null;
 
@@ -150,7 +150,7 @@ public final class FindMeetingQuery {
    * attributes to a Collection of TimeRange objects if they fit the meeting
    * requirements and are valid within a day.
    */
-  private void addTimeRangeIfValid(Collection<TimeRange> availableTimeRanges, TimeRange range, long duration) {
+  private static void addTimeRangeIfValid(Collection<TimeRange> availableTimeRanges, TimeRange range, long duration) {
     if (range.start() < range.end() && range.end() - range.start() >= duration) {
       availableTimeRanges.add(range);
     }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -26,8 +26,9 @@ public final class FindMeetingQuery {
 
   /**
    * Returns a Collection of TimeRange objects representing possible intervals of
-   * a certain meeting occurring, with all participants able to go and having a
-   * certain possible duration.
+   * a certain meeting occurring, with all participants able to go. If the 
+   * request parameter has optional attendees, they will be accounted for
+   * unless they block the meeting from occurring entirely.
    * 
    * @param events  A Collection of Event objects formed before the creation of
    *                this meeting

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -55,6 +55,17 @@ public final class FindMeetingQuery {
     return getValidMeetingTimeRanges(requiredTimeRanges, request);
   }
 
+  /**
+   * Computes the valid meeting time ranges according to a certain MeetingRequest
+   * and list of busy time ranges where the attendees cannot attend.
+   * 
+   * @param busyTimeRanges list of TimeRange objects representing the busy time
+   *                       ranges, sorted, for a certain group.
+   * @param request        MeetingRequest object representing the meeting
+   *                       requirements
+   * @return Collection of TimeRange objects representing valid meeting time
+   *         intervals
+   */
   private Collection<TimeRange> getValidMeetingTimeRanges(List<TimeRange> busyTimeRanges, MeetingRequest request) {
     Collections.sort(busyTimeRanges, TimeRange.ORDER_BY_START);
     discretizeSortedTimeRanges(busyTimeRanges);
@@ -103,7 +114,6 @@ public final class FindMeetingQuery {
         }
       }
     }
-    Collections.sort(busyTimeRanges, TimeRange.ORDER_BY_START);
     return busyTimeRanges;
   }
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -25,19 +25,40 @@ import java.util.Set;
 public final class FindMeetingQuery {
 
   /**
-   * Returns a Collection of TimeRange objects representing possible intervals of a certain meeting
-   * occurring, with all participants able to go and having a certain possible duration.
-   * @param  events  A Collection of Event objects formed before the creation of this meeting
-   * @param  request A MeetingRequest object representing the meeting data.
+   * Returns a Collection of TimeRange objects representing possible intervals of
+   * a certain meeting occurring, with all participants able to go and having a
+   * certain possible duration.
+   * 
+   * @param events  A Collection of Event objects formed before the creation of
+   *                this meeting
+   * @param request A MeetingRequest object representing the meeting data.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    List<TimeRange> busyTimeRanges = getBusyTimeRanges(events, request.getAttendees());
-    Collections.sort(busyTimeRanges, TimeRange.ORDER_BY_START);
-    discretizeSortedTimeRanges(busyTimeRanges);
+    List<TimeRange> requiredTimeRanges = getBusyTimeRanges(events, request.getAttendees());
+    List<TimeRange> optionalBusyTimeRanges = getBusyTimeRanges(events, request.getOptionalAttendees());
+    List<TimeRange> optionalAndRequiredTimeRanges = new ArrayList<>(
+        requiredTimeRanges.size() + optionalBusyTimeRanges.size());
+    optionalAndRequiredTimeRanges.addAll(requiredTimeRanges);
+    optionalAndRequiredTimeRanges.addAll(optionalBusyTimeRanges);
 
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       return Arrays.asList();
     }
+
+    Collection<TimeRange> validMeetingTimesWithOptional = getValidMeetingTimeRanges(optionalAndRequiredTimeRanges,
+        request);
+
+    if (validMeetingTimesWithOptional.size() > 0) {
+      return validMeetingTimesWithOptional;
+    }
+
+    return getValidMeetingTimeRanges(requiredTimeRanges, request);
+  }
+
+  private Collection<TimeRange> getValidMeetingTimeRanges(List<TimeRange> busyTimeRanges, MeetingRequest request) {
+    Collections.sort(busyTimeRanges, TimeRange.ORDER_BY_START);
+    discretizeSortedTimeRanges(busyTimeRanges);
+
     if (busyTimeRanges.size() == 0) {
       return Arrays.asList(TimeRange.WHOLE_DAY);
     }
@@ -61,11 +82,14 @@ public final class FindMeetingQuery {
 
     return availableTimeRanges;
   }
-  
+
   /**
-   * Computes a list of all time ranges where all attendees of a meeting are busy
-   * @param  events    Collection of Event objects formed before the creation of this meeting
-   * @param  attendees Collection of attendee string names
+   * Computes a sorted list (by start time) of all time ranges where all attendees
+   * of a meeting are busy
+   * 
+   * @param events    Collection of Event objects formed before the creation of
+   *                  this meeting
+   * @param attendees Collection of attendee string names
    * @return List of time ranges where attendees are engaged in other events.
    */
   private List<TimeRange> getBusyTimeRanges(Collection<Event> events, Collection<String> attendees) {
@@ -79,13 +103,16 @@ public final class FindMeetingQuery {
         }
       }
     }
+    Collections.sort(busyTimeRanges, TimeRange.ORDER_BY_START);
     return busyTimeRanges;
   }
 
   /**
-   * Removes nested and overlapping time ranges in a certain sorted List 
-   * of TimeRange objects
-   * @param  sortedtimeRanges  List of TimeRange objects that must be ordered by starting time
+   * Removes nested and overlapping time ranges in a certain sorted List of
+   * TimeRange objects
+   * 
+   * @param sortedtimeRanges List of TimeRange objects that must be ordered by
+   *                         starting time
    */
   private void discretizeSortedTimeRanges(List<TimeRange> sortedTimeRanges) {
     ListIterator<TimeRange> iter = sortedTimeRanges.listIterator();
@@ -106,8 +133,9 @@ public final class FindMeetingQuery {
   }
 
   /**
-   * Adds a time range with certain start, end, duration, and inclusitivity attributes to a Collection of 
-   * TimeRange objects if they fit the meeting requirements and are valid within a day.
+   * Adds a time range with certain start, end, duration, and inclusitivity
+   * attributes to a Collection of TimeRange objects if they fit the meeting
+   * requirements and are valid within a day.
    */
   private void addTimeRangeIfValid(Collection<TimeRange> availableTimeRanges, TimeRange range, long duration) {
     if (range.start() < range.end() && range.end() - range.start() >= duration) {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -139,7 +139,7 @@ public final class FindMeetingQuery {
           int end = Math.max(prevTimeRange.end(), curr.end());
           iter.set(TimeRange.fromStartEnd(prevTimeRange.start(), end, false));
         } else {
-          prevTimeRange == curr;
+          prevTimeRange = curr;
         }
       }
     }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -70,156 +70,167 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void noOptionsForTooLongOfARequest() {
-    // The duration should be longer than a day. This means there should be no
-    // options.
+    // The duration should be longer than a day. This means there should be no options.
     int duration = TimeRange.WHOLE_DAY.duration() + 1;
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), duration);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
     Collection<TimeRange> expected = Arrays.asList();
-
+  
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void eventSplitsRestriction() {
     // The event should split the day into two options (before and after the event).
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+    Collection<Event> events = Arrays.asList(new Event("Event 1",
+        TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-        TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void everyAttendeeIsConsidered() {
-    // Have each person have different events. We should see two options because
-    // each person has
+    // Have each person have different events. We should see two options because each person has
     // split the restricted times.
     //
-    // Events : |--A--| |--B--|
-    // Day : |-----------------------------|
-    // Options : |--1--| |--2--| |--3--|
+    // Events  :       |--A--|     |--B--|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_B)));
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
-        TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
-        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void overlappingEvents() {
-    // Have an event for each person, but have their events overlap. We should only
-    // see two options.
+    // Have an event for each person, but have their events overlap. We should only see two options.
     //
-    // Events : |--A--|
-    // |--B--|
-    // Day : |---------------------|
-    // Options : |--1--| |--2--|
+    // Events  :       |--A--|
+    //                     |--B--|
+    // Day     : |---------------------|
+    // Options : |--1--|         |--2--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES), Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES), Arrays.asList(PERSON_B)));
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void nestedEvents() {
-    // Have an event for each person, but have one person's event fully contain
-    // another's event. We
+    // Have an event for each person, but have one person's event fully contain another's event. We
     // should see two options.
     //
-    // Events : |----A----|
-    // |--B--|
-    // Day : |---------------------|
-    // Options : |--1--| |--2--|
+    // Events  :       |----A----|
+    //                   |--B--|
+    // Day     : |---------------------|
+    // Options : |--1--|         |--2--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES), Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_B)));
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_90_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
 
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void doubleBookedPeople() {
-    // Have one person, but have them registered to attend two events at the same
-    // time.
+    // Have one person, but have them registered to attend two events at the same time.
     //
-    // Events : |----A----|
-    // |--A--|
-    // Day : |---------------------|
-    // Options : |--1--| |--2--|
+    // Events  :       |----A----|
+    //                     |--A--|
+    // Day     : |---------------------|
+    // Options : |--1--|         |--2--|
 
     Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES), Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0830AM, DURATION_60_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
-        TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void justEnoughRoom() {
-    // Have one person, but make it so that there is just enough room at one point
-    // in the day to
+    // Have one person, but make it so that there is just enough room at one point in the day to
     // have the meeting.
     //
-    // Events : |--A--| |----A----|
-    // Day : |---------------------|
-    // Options : |-----|
+    // Events  : |--A--|     |----A----|
+    // Day     : |---------------------|
+    // Options :       |-----|
 
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true), Arrays.asList(PERSON_A)));
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
 
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void ignoresPeopleNotAttending() {
-    // Add an event, but make the only attendee someone different from the person
-    // looking to book
+    // Add an event, but make the only attendee someone different from the person looking to book
     // a meeting. This event should not affect the booking.
-    Collection<Event> events = Arrays.asList(
-        new Event("Event 1", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
+    Collection<Event> events = Arrays.asList(new Event("Event 1",
+        TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES), Arrays.asList(PERSON_A)));
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
@@ -230,7 +241,8 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void noConflicts() {
-    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
 
     Collection<TimeRange> actual = query.query(NO_EVENTS, request);
     Collection<TimeRange> expected = Arrays.asList(TimeRange.WHOLE_DAY);
@@ -240,18 +252,18 @@ public final class FindMeetingQueryTest {
 
   @Test
   public void notEnoughRoom() {
-    // Have one person, but make it so that there is not enough room at any point in
-    // the day to
+    // Have one person, but make it so that there is not enough room at any point in the day to
     // have the meeting.
     //
-    // Events : |--A-----| |-----A----|
-    // Day : |---------------------|
+    // Events  : |--A-----| |-----A----|
+    // Day     : |---------------------|
     // Options :
 
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true), Arrays.asList(PERSON_A)));
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
 

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -340,9 +340,8 @@ public final class FindMeetingQueryTest {
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(
-        TimeRange.fromStartEnd(TIME_0800AM, TIME_0900AM, false),
-        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true)));
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TIME_0800AM, TIME_0900AM, false),
+        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
   }

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -332,17 +332,17 @@ public final class FindMeetingQueryTest {
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
             Arrays.asList(PERSON_A)),
-        new Event("Event 2", TimeRange.fromStartEnd(TIME_0930AM, TIME_1000AM, true), Arrays.asList(PERSON_B)),
-        new Event("Event 3", TimeRange.fromStartEnd(TIME_0900AM, TIME_0930AM, true), Arrays.asList(PERSON_B)));
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0930AM, TIME_1000AM, false), Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0900AM, TIME_0930AM, false), Arrays.asList(PERSON_B)));
 
     MeetingRequest request = new MeetingRequest(NO_ATTENDEES, DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_A);
     request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
-    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+    Collection<TimeRange> expected = Arrays.asList(TimeRange.fromStartEnd(
         TimeRange.fromStartEnd(TIME_0800AM, TIME_0900AM, false),
-        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true));
+        TimeRange.fromStartEnd(TIME_1000AM, TimeRange.END_OF_DAY, true)));
 
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
### Summary
This PR implements support for optional attendees in the Meeting Planning feature of Week 5, finishing the full functionality of the app. Optional attendees are best attempted to be included in meetings unless they block a meeting from happening entirely.

### Screenshots
N/A

### Test Plan
**Testing Rationale:** In order to best cover regular and corner cases, I tested the following 5 scenarios:
  - Optional attendee has an all-day event, making them ignored in the meeting time range selection
  - Optional attendee has a single event that rules out that time range but not the rest of time ranges.
  - There is just enough room for a meeting to occur, but optional attendee is busy during that time. They will be ignored.
  - If meeting has optional attendees only, they are treated like regular attendees.
  - Optional attendees have meetings that allow for no gaps -> no possible meetings.

Run `mvn test` in `/walkthroughs/week-5-tdd/project` to evaluate the test cases stored in `FindMeetingQueryTest.java`. See that all the tests pass (including previous ones and the 5 new ones).

### Notes
  - The diffcount of this PR is bigger mostly due to the new tests, sorry about that.
  - The frontend of the app for optional attendees does not work, and the original [repo](https://github.com/googleinterns/step/pull/38) has only recently corrected this. I may update this satellite repo, but I'm content seeing that the query method is functional from the tests.